### PR TITLE
Add new appdaemon app [joBr99/nspanel-lovelace-ui]

### DIFF
--- a/appdaemon
+++ b/appdaemon
@@ -23,6 +23,7 @@
   "jbouwh/ha-entity-cache",
   "jbouwh/omnikdatalogger",
   "jmarsik/ad-eurotronic-trv-valvepos",
+  "joBr99/nspanel-lovelace-ui",
   "kprestel/appdaemon-climate",
   "ludeeus/ad-watchdog",
   "Mohlsson/ReplayLightsHistory",


### PR DESCRIPTION
Add's a new appdaemon app, which is used to connect home assistant with a custom UI for Sonoff NSPanel.